### PR TITLE
Update to `egui 0.30.0` & `eframe 0.30.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ exclude = ["media/**"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.29.1"
+egui = "0.30.0"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-eframe  = "0.29.1" # used in example
+eframe = "0.30.0" # used in example
 
 [features]
 serde = ["dep:serde", "egui/serde"]


### PR DESCRIPTION
`egui` has updated to version `0.30.0` & I am hoping that `egui-keybind` can be updated to use `egui 0.30.0`.

I compiled the code & ran the example on my local machine without any issues using `egui` & `eframe` version `0.30.0`.
I haven't modified any other code as I did not encounter any issues.

I will be happy to make any other changes if needed.