### PR TITLE
Update egui to 0.31.0 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ exclude = ["media/**"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.30.0"
+egui = "0.31.0"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-eframe = "0.30.0" # used in example
+eframe = "0.31.0" # used in example
 
 [features]
 serde = ["dep:serde", "egui/serde"]

--- a/src/bind.rs
+++ b/src/bind.rs
@@ -170,10 +170,7 @@ impl Shortcut {
     /// * `keyboard` - The keyboard shortcut to set ([KeyboardShortcut]), or [None].
     /// * `pointer` - The pointer button to set ([PointerButton]), or [None].
     pub fn new(keyboard: Option<KeyboardShortcut>, pointer: Option<PointerButton>) -> Self {
-        Self {
-            keyboard,
-            pointer,
-        }
+        Self { keyboard, pointer }
     }
 
     /// Keyboard shortcut, if any. This can be set along with the mouse shortcut.

--- a/src/keybind.rs
+++ b/src/keybind.rs
@@ -1,4 +1,5 @@
 use crate::Bind;
+use egui::epaint::StrokeKind;
 use egui::{
     pos2, vec2, Event, Id, Key, KeyboardShortcut, ModifierNames, PointerButton, RichText, Sense,
     TextStyle, Ui, Widget, WidgetInfo, WidgetText, WidgetType,
@@ -224,9 +225,10 @@ impl<'a, B: Bind> Widget for Keybind<'a, B> {
             let visuals = ui.style().interact_selectable(&response, expecting);
             ui.painter().rect(
                 hotkey_rect.expand(visuals.expansion),
-                visuals.rounding,
+                visuals.corner_radius,
                 visuals.bg_fill,
                 visuals.bg_stroke,
+                StrokeKind::Inside,
             );
 
             // align text to center in rect that is shrinked to match button padding


### PR DESCRIPTION
Updated the egui dependencies to 0.31.0 following the patches in the official migration [guide:](https://github.com/emilk/egui/releases/tag/0.31.0)
- change `rounding` to `corner_radius`;
- Add a `StrokeKind::Inside` to `rect()` call.

After the modifications the example works on my computer.